### PR TITLE
Support a single pedal/lever at a time, set rest of D13 copedent, improve chord filtering, refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in copedent.gemspec
 gemspec
+
+gem "pry", "~> 0.15.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.3)
+    method_source (1.1.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
@@ -17,6 +22,7 @@ PLATFORMS
 
 DEPENDENCIES
   copedent!
+  pry (~> 0.15.2)
 
 BUNDLED WITH
    2.6.2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # copedent
-Quick script to help me analyze my pedal steel copedent.
+Small app to help me analyze my pedal steel copedent.
 
 ## What's a pedal steel?
 
@@ -9,10 +9,10 @@ It's a [stringed instrument](https://en.wikipedia.org/wiki/Pedal_steel_guitar) u
 
 *Cho*rd *Ped*al Arrangm*ent*. It's a description for how a pedal steel is tuned and what the pedals and knee levers do.
 
-## Why would you need a Ruby script for this?
+## Why would you need a Ruby app for this?
 
 Some pedal steels have a few pedals and knee levers, some have a lot - mine has a lot. This tool lets me iterate on the setup quickly in a way that works well for my musical understanding instead of chewing through a lot of paper or Excel spreadsheets. A bit of planning saves a lot of time messing with mechanics.
 
-## Why a script instead of something cleaner/nicer/more complex?
+## Why a pure Ruby gem instead of something cleaner/nicer/more complex?
 
-To the above point, I'm building this in an hour or two to free myself up to spend more time on the music. Maybe sometime I'll come back and build this into a web app so it's easier for others to use, too.
+I already spend plenty of time on Rails, but not as much as I'd like in unconventional Ruby setups, so this is just as educational. Maybe sometime I'll come back and build this into a web app so it's easier for others to use, too, though.

--- a/bin/run
+++ b/bin/run
@@ -27,7 +27,7 @@ CHANGELIST = {
   ],
   p2: [
     Copedent::Change.new(string: 7, modifier: 1),
-    Copedent::Change.new(string: 3, modifier: 2)
+    Copedent::Change.new(string: 3, modifier: 1)
   ],
   p3: [
     Copedent::Change.new(string: 6, modifier: 2),

--- a/bin/run
+++ b/bin/run
@@ -6,22 +6,85 @@ require_relative "../lib/copedent"
 # === PER-RUN USER CONFIG ===
 
 ROOT = "D"
-TYPES = [:major, :minor, :dom7]
+
+CHORD_TYPES = [:major, :minor, :dom7]
+OPEN_VOICINGS = true
+MAX_COMBOS = 3
+OPTS = {chord_types: CHORD_TYPES, open_voicings: OPEN_VOICINGS, max_combos: MAX_COMBOS}
+
 MAX_VISIBLE_FRETS = 4
+CSV_FILENAME = "#{CHORD_TYPES.map(&:to_s).join("_")}_#{Time.now.to_i}_export.csv"
 ENABLE_CLI = true
 ENABLE_CSV = true
-CSV_FILENAME = "#{TYPES.map(&:to_s).join("_")}_#{Time.now.to_i}_export.csv"
 
 # high to low, add 1 to index to get to a string #
 TUNING = ["E", "C#", "F#", "D", "B", "A", "F#", "E", "D", "C", "A", "D"]
+
+CHANGELIST = {
+  p1: [
+    Copedent::Change.new(string: 6, modifier: 2),
+    Copedent::Change.new(string: 4, modifier: 2)
+  ],
+  p2: [
+    Copedent::Change.new(string: 7, modifier: 1),
+    Copedent::Change.new(string: 3, modifier: 2)
+  ],
+  p3: [
+    Copedent::Change.new(string: 6, modifier: 2),
+    Copedent::Change.new(string: 11, modifier: 2)
+  ],
+  p4: [
+    Copedent::Change.new(string: 6, modifier: -2),
+    Copedent::Change.new(string: 12, modifier: 2)
+  ],
+  p5: [
+    Copedent::Change.new(string: 8, modifier: -1),
+    Copedent::Change.new(string: 10, modifier: -1),
+    Copedent::Change.new(string: 11, modifier: -3),
+    Copedent::Change.new(string: 12, modifier: -3)
+  ],
+  p6: [
+    Copedent::Change.new(string: 6, modifier: -1),
+    Copedent::Change.new(string: 10, modifier: -1),
+    Copedent::Change.new(string: 11, modifier: -1),
+    Copedent::Change.new(string: 12, modifier: 2)
+  ],
+  p7: [
+    Copedent::Change.new(string: 3, modifier: 1),
+    Copedent::Change.new(string: 7, modifier: -1)
+  ],
+  lkl: [
+    Copedent::Change.new(string: 4, modifier: -1),
+    Copedent::Change.new(string: 9, modifier: -1)
+  ],
+  lkv: [
+    Copedent::Change.new(string: 1, modifier: 2),
+    Copedent::Change.new(string: 2, modifier: 1),
+    Copedent::Change.new(string: 7, modifier: -2)
+  ],
+  lkr: [
+    Copedent::Change.new(string: 4, modifier: 1),
+    Copedent::Change.new(string: 9, modifier: 1)
+  ],
+  rkl: [
+    Copedent::Change.new(string: 2, modifier: -2),
+    Copedent::Change.new(string: 5, modifier: -1)
+  ],
+  rkr: [
+    Copedent::Change.new(string: 3, modifier: -2),
+    Copedent::Change.new(string: 10, modifier: -1),
+    Copedent::Change.new(string: 11, modifier: -2)
+  ],
+}
 
 # ========
 
 def main
   analysis = Copedent::Sheet.new(
-    tuning: TUNING,
     root: ROOT,
-    types: TYPES
+    tuning: TUNING,
+    changelist: CHANGELIST,
+    opts: OPTS
   ).analyze()
 
   if ENABLE_CLI

--- a/lib/copedent.rb
+++ b/lib/copedent.rb
@@ -4,8 +4,11 @@ require_relative "copedent/version"
 require_relative "copedent/sheet"
 require_relative "copedent/printer"
 require_relative "copedent/fret"
+require_relative "copedent/change"
+
 require "terminal-table"
 require "csv"
+require "pry"
 
 # TODO - look for multiple combinations of the triad for chord quality
 #        ie need any?([1,3], [3,5]) for major, not just 3
@@ -19,10 +22,4 @@ module Copedent
   ALL_TYPES = [:major, :minor, :dom7] # unused, for reference
 
   ALL_NOTES = ["E", "F", "F#", "G", "G#", "A", "A#", "B", "C", "C#", "D", "D#"]
-
-  # TODO: allow passing in aliases (e.g. :a for :p1)
-  # TODO: these should all be passed in?
-  PEDAL_NAMES = [:p0, :p1, :p2, :p3, :p4, :p5, :p6, :p7, :p8]
-  LEVER_NAMES = [:lkl1, :lkl2, :lkv, :lkr, :rkl, :rkr]
-  ALL_MODS = PEDAL_NAMES | LEVER_NAMES
 end

--- a/lib/copedent.rb
+++ b/lib/copedent.rb
@@ -3,6 +3,7 @@
 require_relative "copedent/version"
 require_relative "copedent/sheet"
 require_relative "copedent/printer"
+require_relative "copedent/fret"
 require "terminal-table"
 require "csv"
 
@@ -12,26 +13,16 @@ require "csv"
 # TODO add a hash or first-class object for frets
 # TODO need to choose a CLI tools library
 
-# holds everything for now, will break out into more classes soon
 module Copedent
-  # === STATIC CONFIG ===
+  class CopedentError < StandardError; end
 
   ALL_TYPES = [:major, :minor, :dom7] # unused, for reference
 
   ALL_NOTES = ["E", "F", "F#", "G", "G#", "A", "A#", "B", "C", "C#", "D", "D#"]
 
-  # TODO - look for multiple combinations of the triad
-  QUALITIES = {
-    major: ["3"],
-    minor: ["b3"],
-    dom7: ["3", "b7"]
-  }
-
-  # TODO: use the 9+ qualities for QoL
-  RELATIONS = [
-    "Root", "b2", "2", "b3", "3",
-    "4", "b5", "5", "#5", "6", "b7",
-    "maj7", "Root", "b9", "9", "#9",
-    "11", "#11", "b13", "13"
-  ]
+  # TODO: allow passing in aliases (e.g. :a for :p1)
+  # TODO: these should all be passed in?
+  PEDAL_NAMES = [:p0, :p1, :p2, :p3, :p4, :p5, :p6, :p7, :p8]
+  LEVER_NAMES = [:lkl1, :lkl2, :lkv, :lkr, :rkl, :rkr]
+  ALL_MODS = PEDAL_NAMES | LEVER_NAMES
 end

--- a/lib/copedent/change.rb
+++ b/lib/copedent/change.rb
@@ -3,9 +3,21 @@
 # glorified tuple of (string (ie index of tuning +1), modifier)
 module Copedent
   class Change
+    attr_accessor :string, :modifier, :note
+
     def initialize(string:, modifier:)
       @string = string
       @modifier = modifier
+    end
+
+    def note_index
+      @string - 1
+    end
+
+    # ruby pattern would be to name `note` and memoize, but i find this misleading and bad
+    # it's good to break patterns sometimes
+    def set_note(tuning:, key:)
+      @note = shift_note(note: tuning[note_index], amount: @modifier, key:,)
     end
 
     def validate!
@@ -13,6 +25,15 @@ module Copedent
       raise CopedentError.new("string must be > 0") unless @string > 0
 
       raise CopedentError.new("modifier must be an int") unless @modifer.is_a?(Int)
+    end
+
+    private
+
+    # TODO - changer module?
+    def shift_note(note:, amount:, key:)
+      current_index = key.find_index(note)
+      new_index = (current_index + amount) % key.length
+      key[new_index]
     end
   end
 end

--- a/lib/copedent/change.rb
+++ b/lib/copedent/change.rb
@@ -1,0 +1,18 @@
+# describes a single change (raise or lower) in a copedent
+# measured in semitones/half-tones
+# glorified tuple of (string (ie index of tuning +1), modifier)
+module Copedent
+  class Change
+    def initialize(string:, modifier:)
+      @string = string
+      @modifier = modifier
+    end
+
+    def validate!
+      raise CopedentError.new("string must be an int") unless @string.is_a?(Int)
+      raise CopedentError.new("string must be > 0") unless @string > 0
+
+      raise CopedentError.new("modifier must be an int") unless @modifer.is_a?(Int)
+    end
+  end
+end

--- a/lib/copedent/change.rb
+++ b/lib/copedent/change.rb
@@ -17,7 +17,7 @@ module Copedent
     # ruby pattern would be to name `note` and memoize, but i find this misleading and bad
     # it's good to break patterns sometimes
     def set_note(tuning:, key:)
-      @note = shift_note(note: tuning[note_index], amount: @modifier, key:,)
+      @note = shift_note(note: tuning[note_index], amount: @modifier, key:)
     end
 
     def validate!

--- a/lib/copedent/fret.rb
+++ b/lib/copedent/fret.rb
@@ -4,9 +4,9 @@
 module Copedent
   # TODO - look for multiple combinations of the triad
   QUALITIES = {
-    major: ["3"],
-    minor: ["b3"],
-    dom7: ["3", "b7"]
+    major: [["Root", "3"], ["3", "maj7"]],
+    minor: [["Root", "b3"], ["b3", "b7"]],
+    dom7: [["3", "b7"]]
   }
 
   # TODO: use the 9+ qualities for QoL
@@ -25,11 +25,13 @@ module Copedent
       @relations = relations_for(tuning:, fret_num:)
     end
 
+    # TODO: make this not static, probably
     # check if the given fret has all of the required chord qualities for configured chords
     # e.g. a major chord must have a 3, but a dom 7 must have a 3 and a b7
-    def has_valid_chord?(types:)
+    def self.has_valid_chord?(fret:, types:)
+      notes = fret.transpose[3]
       types.any? do |type|
-        QUALITIES[type].all? { |qual| @relations.include?(qual) }
+        QUALITIES[type].any? { |combo| combo.all? { |qual| notes.include?(qual) } }
       end
     end
 

--- a/lib/copedent/fret.rb
+++ b/lib/copedent/fret.rb
@@ -37,7 +37,7 @@ module Copedent
     def generate_columns(changelist:)
       single_mods = changelist.map do |name, list|
         overrides = list.each_with_object({}) do |change, hsh|
-          hsh[change.note_index] = change.note
+          hsh[change.note_index] = {note: change.note, name:}
         end
 
         generate_column_for(mapping: @tuning, overrides:, names: [name])
@@ -54,14 +54,14 @@ module Copedent
     # we are aligned on string index here but it would be better to use string # in the future
     def generate_column_for(mapping:, overrides: {}, names: [])
       col = mapping.map.with_index do |note, idx|
-        note = overrides[idx] unless overrides[idx].nil?
+        note = overrides[idx][:note] unless overrides[idx].nil?
         ["", idx + 1, note, relation(note:)]
       end
 
       # add extra info to the reserved title column
       col[0][0] = @fret_num
-      names.each_with_index do |name, idx|
-        col[1 + idx][0] = name.to_s
+      overrides.keys.each do |idx|
+        col[idx][0] = overrides[idx][:name].to_s
       end
 
       col

--- a/lib/copedent/fret.rb
+++ b/lib/copedent/fret.rb
@@ -20,32 +20,41 @@ module Copedent
     attr_accessor :data
 
     def initialize(tuning:, key:, fret_num:)
-      @tuning = tuning
+      @tuning = shift_tuning(tuning:, key:, fret_num:)
       @key = key
       @fret_num = fret_num
-      # TODO: revisit this - refactor-driven design
-      @data = convert_fret(tuning:, key:, fret_num:)
+      @relations = relations_for(tuning:, key:, fret_num:)
     end
 
     # check if the given fret has all of the required chord qualities for configured chords
     # e.g. a major chord must have a 3, but a dom 7 must have a 3 and a b7
     def has_valid_chord?(types:)
-      # transpose is done since these are columns instead of rows
-      notes = @data.transpose[3]
       types.any? do |type|
-        QUALITIES[type].all? { |qual| notes.include?(qual) }
+        QUALITIES[type].all? { |qual| @relations.include?(qual) }
+      end
+    end
+
+    def apply_changes(changes)
+      raise CopedentError.new("Must be an Array") unless changes.is_a?(Array)
+
+      changes.map { |change| apply_change(change) }
+    end
+
+    # used for printing
+    def generate_column
+      @tuning.map.with_index do |note, idx|
+        fret = idx.zero? ? @fret_num : ""
+        [fret, idx + 1, note, relation(key: @key, note:)]
       end
     end
 
     private
 
-    def convert_fret(tuning:, key:, fret_num:)
-      shift_tuning(tuning:, key:, fret_num:)
-        .map
-        .with_index do |note, idx|
-          fret = idx.zero? ? fret_num : ""
-          [fret, idx + 1, note, relation(key:, note:)]
-        end
+    def apply_change(change)
+    end
+
+    def relations_for(tuning:, key:, fret_num:)
+      @tuning.map { |note| relation(key:, note:) }
     end
 
     def shift_tuning(tuning:, key:, fret_num:)

--- a/lib/copedent/fret.rb
+++ b/lib/copedent/fret.rb
@@ -1,0 +1,64 @@
+# models a single fret, or single complete column of analysis
+# long-term, might be better to do this less similarly to how it's done irl
+module Copedent
+  # TODO - look for multiple combinations of the triad
+  QUALITIES = {
+    major: ["3"],
+    minor: ["b3"],
+    dom7: ["3", "b7"]
+  }
+
+  # TODO: use the 9+ qualities for QoL
+  RELATIONS = [
+    "Root", "b2", "2", "b3", "3",
+    "4", "b5", "5", "#5", "6", "b7",
+    "maj7", "Root", "b9", "9", "#9",
+    "11", "#11", "b13", "13"
+  ]
+
+  class Fret
+    attr_accessor :data
+
+    def initialize(tuning:, key:, fret_num:)
+      @tuning = tuning
+      @key = key
+      @fret_num = fret_num
+      # TODO: revisit this - refactor-driven design
+      @data = convert_fret(tuning:, key:, fret_num:)
+    end
+
+    # check if the given fret has all of the required chord qualities for configured chords
+    # e.g. a major chord must have a 3, but a dom 7 must have a 3 and a b7
+    def has_valid_chord?(types:)
+      # transpose is done since these are columns instead of rows
+      notes = @data.transpose[3]
+      types.any? do |type|
+        QUALITIES[type].all? { |qual| notes.include?(qual) }
+      end
+    end
+
+    private
+
+    def convert_fret(tuning:, key:, fret_num:)
+      shift_tuning(tuning:, key:, fret_num:)
+        .map
+        .with_index do |note, idx|
+          fret = idx.zero? ? fret_num : ""
+          [fret, idx + 1, note, relation(key:, note:)]
+        end
+    end
+
+    def shift_tuning(tuning:, key:, fret_num:)
+      tuning.map do |note|
+        current_index = key.find_index(note)
+        new_index = (current_index + fret_num) % key.length
+        key[new_index]
+      end
+    end
+
+    def relation(key:, note:)
+      interval = key.find_index(note)
+      RELATIONS[interval]
+    end
+  end
+end

--- a/lib/copedent/sheet.rb
+++ b/lib/copedent/sheet.rb
@@ -1,10 +1,12 @@
 # parameters and logic for a complete Sheet of analysis, which is several Frets
 module Copedent
   class Sheet
-    def initialize(tuning:, root:, types:)
-      @tuning = tuning
+    def initialize(root:, tuning:, changelist:, opts:)
       @root = root
-      @types = types
+      @tuning = tuning
+      @changelist = changelist
+      @chord_types = opts[:chord_types]
+      @opts = opts
     end
 
     def analyze
@@ -14,8 +16,8 @@ module Copedent
       # it only makes sense to do so in columnar blocks
       (0..11)
         .map { |fret_num| Fret.new(tuning: @tuning, key:, fret_num:) }
-        .select { |fret| fret.has_valid_chord?(types: @types) }
-        .map(&:data)
+        .select { |fret| fret.has_valid_chord?(types: @chord_types) }
+        .map(&:generate_column)
     end
 
     private

--- a/lib/copedent/sheet.rb
+++ b/lib/copedent/sheet.rb
@@ -15,8 +15,8 @@ module Copedent
       # it only makes sense to do so in columnar blocks
       (0..11)
         .map { |fret_num| Fret.new(tuning: @tuning, key: @key, changelist: @changelist, fret_num:) }
-        .select { |fret| fret.has_valid_chord?(types: @chord_types) }
         .flat_map { |fret| fret.generate_columns(changelist: @changelist) }
+        .select { |col| Fret.has_valid_chord?(fret: col, types: @chord_types) }
     end
 
     private

--- a/lib/copedent/sheet.rb
+++ b/lib/copedent/sheet.rb
@@ -16,7 +16,7 @@ module Copedent
       (0..11)
         .map { |fret_num| Fret.new(tuning: @tuning, key: @key, changelist: @changelist, fret_num:) }
         .select { |fret| fret.has_valid_chord?(types: @chord_types) }
-        .flat_map(&:generate_columns)
+        .flat_map { |fret| fret.generate_columns(changelist: @changelist) }
     end
 
     private

--- a/lib/copedent/sheet.rb
+++ b/lib/copedent/sheet.rb
@@ -1,4 +1,4 @@
-# parameters and logic for a single Sheet of analysis
+# parameters and logic for a complete Sheet of analysis, which is several Frets
 module Copedent
   class Sheet
     def initialize(tuning:, root:, types:)
@@ -13,8 +13,9 @@ module Copedent
       # the copedent is read column-wise, so to make partial calculations,
       # it only makes sense to do so in columnar blocks
       (0..11)
-        .map { |fret| convert_fret(tuning: @tuning, key:, fret:) }
-        .select { |fret| has_valid_chord?(fret:, types: @types) }
+        .map { |fret_num| Fret.new(tuning: @tuning, key:, fret_num:) }
+        .select { |fret| fret.has_valid_chord?(types: @types) }
+        .map(&:data)
     end
 
     private
@@ -25,41 +26,6 @@ module Copedent
         .to_a # rails .split() would avoid the type fixup
         .reverse
         .flatten
-    end
-
-    # TODO - consider making a fret class
-    # returns a fret, which is several columns and rows
-    # long-term, might be better to do this less similarly to how it's done irl
-    def convert_fret(tuning:, key:, fret:)
-      shift_tuning(tuning:, key:, fret:)
-        .map
-        .with_index do |note, idx|
-          fret_num = idx.zero? ? fret : ""
-          [fret_num, idx + 1, note, relation(key:, note:)]
-        end
-    end
-
-    # check if the given fret has all of the required chord qualities for configured chords
-    # e.g. a major chord must have a 3, but a dom 7 must have a 3 and a b7
-    def has_valid_chord?(fret:, types:)
-      # transpose is done since these are columns instead of rows
-      notes = fret.transpose[3]
-      types.any? do |type|
-        QUALITIES[type].all? { |qual| notes.include?(qual) }
-      end
-    end
-
-    def shift_tuning(tuning:, key:, fret:)
-      tuning.map do |note|
-        current_index = key.find_index(note)
-        new_index = (current_index + fret) % key.length
-        key[new_index]
-      end
-    end
-
-    def relation(key:, note:)
-      interval = key.find_index(note)
-      RELATIONS[interval]
     end
   end
 end


### PR DESCRIPTION
* Move frets into their own object with their own encapsulated logic
* Create a Change object, analogous to a raise rod on a steel
* Calculate the note a Change generates based on the amount of raise/lower it's set for and the tuning
* Generate the copedent analysis chart based on the changes, up to 1 pedal or lever at a time right now
* Add pry
* Refactor to improve the overall modularity and cleanliness
* Update README to reflect change in effort

![image](https://github.com/user-attachments/assets/3bbd5850-cba6-49fc-a77e-acd21b6e5942)